### PR TITLE
Add non-fixed plane parameters in gurobi optimization

### DIFF
--- a/mader/include/mader_types.hpp
+++ b/mader/include/mader_types.hpp
@@ -629,6 +629,8 @@ struct parameters
   double alpha = 0.0;
   double beta = 0.0;
   double gamma = 0.5;
+
+  bool use_linear_collision_constraints;
 };
 
 typedef std::vector<mt::state> trajectory;

--- a/mader/include/solver_gurobi.hpp
+++ b/mader/include/solver_gurobi.hpp
@@ -195,5 +195,13 @@ private:
   OctopusSearch *octopusSolver_;
 
   double Ra_ = 1e10;
+
+  bool use_linear_collision_constraints_ = true;
+
+  std::vector<GRBLinExpr> d_exp_;      // the scalar parameter of the plane
+  std::vector<std::vector<GRBLinExpr>> n_exp_;  // Each n_exp_[i] has 3 elements (x,y,z)  
+  int solutions_found_ = 0;
+  int total_runs_ = 0;  
+  double time_total_ms_ = 0.0;
 };
 #endif

--- a/mader/include/solver_params.hpp
+++ b/mader/include/solver_params.hpp
@@ -37,6 +37,7 @@ struct par_solver
   double Ra;
 
   double alpha_shrink;
+  bool use_linear_collision_constraints;
 };
 }  // namespace ms
 

--- a/mader/param/mader.yaml
+++ b/mader/param/mader.yaml
@@ -72,6 +72,7 @@ alpha: 0.0 #[m] Error in position
 beta: 0.0 #[m] Deviation between the trajectory and the segment between two discretization points
 gamma: 0.1 #[seconds] >0 Time step between discretization points
 
+use_linear_collision_constraints: true
 
 ##### Not used right now in the MADER algorithm
 fov_horiz_deg: 100 #[deg] \in (0,180] ,  angle between two faces of the tetrahedron 

--- a/mader/src/mader.cpp
+++ b/mader/src/mader.cpp
@@ -92,6 +92,7 @@ Mader::Mader(mt::parameters par) : par_(par)
   par_for_solver.a_star_bias = par_.a_star_bias;
   par_for_solver.allow_infeasible_guess = par_.allow_infeasible_guess;
   par_for_solver.alpha_shrink = par_.alpha_shrink;
+  par_for_solver.use_linear_collision_constraints = par_.use_linear_collision_constraints;
 
   mt::basisConverter basis_converter;
 

--- a/mader/src/mader_ros.cpp
+++ b/mader/src/mader_ros.cpp
@@ -94,6 +94,7 @@ MaderRos::MaderRos(ros::NodeHandle nh1, ros::NodeHandle nh2, ros::NodeHandle nh3
   mu::safeGetParam(nh1_, "fov_horiz_deg", par_.fov_horiz_deg);
   mu::safeGetParam(nh1_, "fov_vert_deg", par_.fov_vert_deg);
   mu::safeGetParam(nh1_, "fov_depth", par_.fov_depth);
+  mu::safeGetParam(nh1_, "use_linear_collision_constraints", par_.use_linear_collision_constraints);
 
   std::cout << "Parameters obtained" << std::endl;
 


### PR DESCRIPTION
This pull request adds the separation plane parameters as optimization variables in Gurobi optimization, thanks to the new Gurobi 9.1 capable of solving non-convex quadratic constraints. It is tested in Ubuntu 18.04 ROS Melodic, with Gurobi 9.1.2.

I have also added a parameter  `use_linear_collision_constraint` to disable/enable using the plane variables in the optimization. When set to true (which is by default), the algorithm works exactly as before.

Performance: using nonconvex quadratic constraints in Gurobi shows significant increase in computation time (~80ms as compared to ~15ms in the single agent random forest test) and a drop in success rate (<80% in the single agent random forest test).

I have also added some printout (commented by default) which can help to evaluate the performance of the optimization.

Hope this is useful.